### PR TITLE
Add splitting and strategy hints to Blackjack

### DIFF
--- a/blackjack_game/test_blackjack.py
+++ b/blackjack_game/test_blackjack.py
@@ -1,5 +1,6 @@
 import unittest
 from blackjack import Deck, Hand, Bankroll
+from blackjack import basic_strategy_hint
 
 class TestDeck(unittest.TestCase):
     """
@@ -112,6 +113,29 @@ class TestBankroll(unittest.TestCase):
         bank = Bankroll(5)
         with self.assertRaises(ValueError):
             bank.bet(10)
+
+
+class TestStrategy(unittest.TestCase):
+    def test_pair_split_hint(self):
+        hand = Hand()
+        hand.add_card(("8", "Hearts"))
+        hand.add_card(("8", "Diamonds"))
+        hint = basic_strategy_hint(hand, "5")
+        self.assertEqual(hint, "Split")
+
+    def test_soft_hint(self):
+        hand = Hand()
+        hand.add_card(("A", "Hearts"))
+        hand.add_card(("7", "Clubs"))
+        hint = basic_strategy_hint(hand, "9")
+        self.assertEqual(hint, "Hit")
+
+    def test_hard_hint(self):
+        hand = Hand()
+        hand.add_card(("5", "Hearts"))
+        hand.add_card(("6", "Clubs"))
+        hint = basic_strategy_hint(hand, "6")
+        self.assertEqual(hint, "Double")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Support splitting and doubling down, handling multiple hands and separate bets.
- Provide a basic strategy hint system that recommends hit, stand, double, or split based on dealer upcard.
- Add unit tests covering the new strategy hint logic.

## Testing
- `cd blackjack_game && python -m unittest test_blackjack.py`

------
https://chatgpt.com/codex/tasks/task_e_6895997150d4833089969b5e823807ba